### PR TITLE
deps: bump chainlit to 2.12.0 (GHSA-w3fx-mc44-mf6j, GHSA-hvfh-5mj3-5f3j)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.7.15"
 description = " VT.ai - Minimal multimodal AI chat app with dynamic conversation routing "
 authors = [{ name = "Vinh Nguyen" }]
 dependencies = [
-    "chainlit==2.11.1",
+    "chainlit==2.12.0",
     "litellm==1.95.0",  # Pinned to avoid malicious versions 1.82.7, 1.82.8 (supply chain attack)
     "openai>=2.52.0",
     "pydantic>=2.13.4",  # Flexible version to resolve conflicts with litellm/chainlit

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "chainlit"
-version = "2.11.1"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -273,9 +273,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/87/080352b58401851f4bc9d595fc222103d431eb3e4bb2df2e9659028d3203/chainlit-2.11.1.tar.gz", hash = "sha256:74b7f801c63f39e7b4d99fd1fa9654df4a97ce01a07c739558566d750b5de3b6", size = 11205431, upload-time = "2026-04-22T00:56:31.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/44/7af8f57c9c1b4c2213cfd9b569e7673b44936abf67a0312e1c999e902003/chainlit-2.12.0.tar.gz", hash = "sha256:53ca71c66fd98d417039ca5fa9c68349eb8eda771b7e0235a7da531f610fe5d0", size = 11264957, upload-time = "2026-08-25T17:01:23.352Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/a2/3bbabfdb6bcbb9b0f952eac62ff277464d6359d126ce8f254ba513c1d4c8/chainlit-2.11.1-py3-none-any.whl", hash = "sha256:7cbd341a6cb2b7788845713dc41f86a44c6b36073dcd0fedb0fc7f230b542ec7", size = 11314614, upload-time = "2026-04-22T00:56:26.413Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/e9/d4bbbcde8b2e3c547a2d55b73840213b45916ff09c9b40cfb8d7875bb4c8/chainlit-2.12.0-py3-none-any.whl", hash = "sha256:17cbd2c408f775a123892984bf9170674b5c81a01f7a8af278912e2786253ffc", size = 11351228, upload-time = "2026-08-25T17:01:20.639Z" },
 ]
 
 [[package]]
@@ -3161,7 +3161,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.3" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=26.5.1" },
-    { name = "chainlit", specifier = "==2.11.1" },
+    { name = "chainlit", specifier = "==2.12.0" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = "==7.3.0" },
     { name = "google-generativeai", specifier = "==0.8.6" },


### PR DESCRIPTION
Updates `chainlit` from 2.11.1 to 2.12.0 to address GHSA-w3fx-mc44-mf6j and GHSA-hvfh-5mj3-5f3j.

Evidence:
- `pyproject.toml` pinned `chainlit==2.11.1`, and `uv.lock` locked `chainlit 2.11.1`
- OSV (api.osv.dev) reports both advisories for `chainlit@2.11.1`:
  - GHSA-w3fx-mc44-mf6j (critical): command injection via MCP stdio transport, unauthenticated RCE
  - GHSA-hvfh-5mj3-5f3j (high): SSRF via MCP SSE and streamable-http transport
- affected range for both: >= 2.4.0rc0, <= 2.11.1; first patched version: 2.12.0
- updated version: `2.12.0`

Validation:
- OSV querybatch for `chainlit@2.12.0` returns no advisories
- `uv sync --locked` installs cleanly (chainlit 2.12.0, 195 packages)
- `uv lock --check` passes on the base branch and on this branch after the change
- `python -c "import chainlit"` loads 2.12.0 under the project venv
- `pip-audit` over the exported locked set (excluding the `semantic-router[fastembed]` extra, whose `fastembed==0.3.0` pin predates this change and fails to resolve on Python 3.13) reports no other vulnerabilities

Note on tests: `pytest tests/unit` fails at collection on both the base branch and this branch (3 errors: `ModuleNotFoundError: No module named 'utils'`; the tests import `utils.*` while the package lives at `vtai.utils`). This is a pre-existing failure unrelated to the bump. The dependency change is the only diff.

Scope: dependency and lockfile update only (`pyproject.toml`, `uv.lock`).
