### PR TITLE
feat: add llmman as a local model provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,10 @@ DEEPSEEK_API_KEY=
 LM_STUDIO_API_BASE=
 LM_STUDIO_API_KEY= # optional, default is empty
 
+## Ollama / llmman (https://github.com/llmmanorg/llmman)
+# Default http://localhost:11434 (Ollama); use http://localhost:17434 for llmman
+OLLAMA_API_BASE=
+
 # Enable LiteLLM Debug Logging
 LITELLM_LOG_LEVEL=
 

--- a/README.md
+++ b/README.md
@@ -104,13 +104,14 @@ For more information about capabilities, see [Usage Guide](docs/user/getting-sta
 
 ### Supported Providers
 
-VT.ai works with OpenAI, Anthropic, Google Gemini, DeepSeek, Cohere, Ollama (local), and more. Set the corresponding environment variable for your provider:
+VT.ai works with OpenAI, Anthropic, Google Gemini, DeepSeek, Cohere, Ollama and [llmman](https://github.com/llmmanorg/llmman) (local), and more. Set the corresponding environment variable for your provider:
 
 ```bash
 export OPENAI_API_KEY="sk-..."        # OpenAI (GPT-o1, GPT-o3, GPT-4o)
 export ANTHROPIC_API_KEY="sk-ant-..." # Anthropic (Claude 3.5/3.7)
 export GEMINI_API_KEY="..."           # Google (Gemini 2.0/2.5)
 export DEEPSEEK_API_KEY="..."         # DeepSeek models
+export OLLAMA_API_BASE="http://localhost:17434" # llmman (Ollama API; default is Ollama on 11434)
 ```
 
 See [Provider Configuration](docs/user/getting-started.md#api-key-configuration) for complete setup instructions.
@@ -251,7 +252,7 @@ vtai
 | **Vision**    | GPT-4o, Gemini 1.5 Pro/Flash, Claude 3, Llama3.2 Vision     |
 | **Image Gen** | GPT-Image-1 with custom parameters                          |
 | **TTS**       | GPT-4o mini TTS, TTS-1, TTS-1-HD                            |
-| **Local**     | Llama3, Mistral, DeepSeek R1 (1.5B to 70B via Ollama)       |
+| **Local**     | Llama3, Mistral, DeepSeek R1 (1.5B to 70B via Ollama); Gemma 4, Qwen3.8, Qwen3.5 (via llmman) |
 
 See [Models Documentation](docs/user/models.md) for detailed model capabilities and configuration.
 

--- a/docs/developer/models.md
+++ b/docs/developer/models.md
@@ -20,7 +20,7 @@ VT.ai comes with built-in support for several providers:
 - OpenAI (GPT-o1, GPT-o3, GPT-4o)
 - Anthropic (Claude models)
 - Google (Gemini models)
-- Local models via Ollama
+- Local models via Ollama or [llmman](https://github.com/llmmanorg/llmman) (Ollama API on port 17434, set `OLLAMA_API_BASE`)
 - And others (DeepSeek, Cohere, etc.)
 
 ### Provider Configuration

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ VT.ai is a sophisticated multimodal AI chat application that integrates multiple
 
 ## Key Features
 
-- **Multi-Provider AI Integration**: Supports OpenAI (o1, o3, 4o), Anthropic (Claude), Google (Gemini), DeepSeek, Meta (Llama), Cohere, local models via Ollama, and more.
+- **Multi-Provider AI Integration**: Supports OpenAI (o1, o3, 4o), Anthropic (Claude), Google (Gemini), DeepSeek, Meta (Llama), Cohere, local models via Ollama or llmman, and more.
 - **Semantic-Based Routing**: Smart routing system that automatically directs queries to specialized handlers based on vector-based classification.
 - **Multimodal Capabilities**: Support for text, image, and audio inputs with vision analysis for images and URLs.
 - **Advanced Image Generation**: Create custom images using DALL-E 3 and GPT-Image-1 with support for transparent backgrounds and multiple output formats.

--- a/docs/user/features.md
+++ b/docs/user/features.md
@@ -260,7 +260,7 @@ VT.ai supports a wide range of models:
 - **Google**: Gemini 1.5 Pro/Flash, Gemini 2.0, Gemini 2.5 Pro/Flash
 - **Vision Models**: GPT-4o, Gemini 1.5 Pro/Flash, Gemini 2.5 Pro/Flash, Claude 3 models, Llama 3.2 Vision
 - **TTS Models**: GPT-4o mini TTS, TTS-1, TTS-1-HD
-- **Local Models**: Llama3, Mistral, DeepSeek R1, Qwen2.5-coder (via Ollama)
+- **Local Models**: Llama3, Mistral, DeepSeek R1, Qwen2.5-coder (via Ollama); Gemma 4, Qwen3.8, Qwen3.5 (via llmman)
 
 You can select models in several ways:
 

--- a/docs/user/models.md
+++ b/docs/user/models.md
@@ -67,6 +67,19 @@ Run models locally for privacy and offline use:
 - **Mistral**: Various versions
 - **Many other open source models**
 
+### Local Models (via llmman)
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API on port 17434 and pulls models from OCI registries or Hugging Face (`hf.co/org/model`). VT.ai uses the same `ollama/` provider; only the base URL changes:
+
+```bash
+llmman serve                                    # start the server
+llmman pull gemma4                              # pull a model
+export OLLAMA_API_BASE="http://localhost:17434" # point VT.ai at llmman
+vtai
+```
+
+Then pick one of the `llmman - ...` models (Gemma 4, Qwen3.8, Qwen3.5 0.8B) in the settings. No API key is required.
+
 ## Model Selection
 
 You can select models in several ways:
@@ -140,7 +153,7 @@ When choosing models, consider these factors:
 - **Quality**: Models like GPT-o1, GPT-4o, and Claude 3 Opus offer higher quality
 - **Cost**: Smaller models generally cost less to use
 - **Multimodal Needs**: Only some models support image analysis
-- **Local Computation**: Ollama models run locally but require more resources
+- **Local Computation**: Ollama and llmman models run locally but require more resources
 - **API Availability**: Some models may require specific API keys
 
 ## API Key Configuration

--- a/vtai/utils/config.py
+++ b/vtai/utils/config.py
@@ -180,6 +180,7 @@ def load_api_keys() -> None:
         "TAVILY_API_KEY",
         "LM_STUDIO_API_BASE",
         "LM_STUDIO_API_KEY",
+        "OLLAMA_API_BASE",
     ]
 
     # Set API keys in environment

--- a/vtai/utils/llm_providers_config.py
+++ b/vtai/utils/llm_providers_config.py
@@ -237,6 +237,11 @@ MODEL_ALIAS_MAP: Dict[str, str] = {
     "Ollama - Command R+": "ollama/command-r-plus",
     "Ollama - Mistral 7B Instruct": "ollama/mistral",
     "Ollama - Mixtral 8x7B Instruct": "ollama/mixtral",
+    # llmman (https://github.com/llmmanorg/llmman) serves the Ollama API;
+    # set OLLAMA_API_BASE=http://localhost:17434 to use these.
+    "llmman - Gemma 4": "ollama/gemma4",
+    "llmman - Qwen3.8": "ollama/qwen3.8",
+    "llmman - Qwen3.5 0.8B (hf.co)": "ollama/hf.co/unsloth/Qwen3.5-0.8B-GGUF",
     # Mistral
     "Mistral Small": "mistral/mistral-small-latest",
     "Mistral Large": "mistral/mistral-large-latest",


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API on port 17434.

- Reuses LiteLLM's `ollama/` provider: llmman speaks the same API, so pointing `OLLAMA_API_BASE` at `http://localhost:17434` is the whole integration (no new transport code).
- Adds three `llmman - ...` presets (`gemma4`, `qwen3.8`, `hf.co/unsloth/Qwen3.5-0.8B-GGUF`) with names llmman resolves; Ollama library names are not guaranteed to exist there.
- Recognises `OLLAMA_API_BASE` in `load_api_keys()` and `.env.example`, next to `LM_STUDIO_API_BASE`; a no-op unless set.
- Documents llmman wherever Ollama is listed (README, `docs/user`, `docs/developer`, `docs/index`).

**Testing:** `py_compile` OK; `ruff check`/`format --check` unchanged vs `main` (pre-existing findings only); `litellm.get_llm_provider()` maps the new IDs to `ollama`. Not run against a live llmman server.

> AI-assisted, reviewed before submitting.
